### PR TITLE
Adapt to qemu Q35 & kernel time simplification

### DIFF
--- a/h2o/boot/src/mem.rs
+++ b/h2o/boot/src/mem.rs
@@ -97,7 +97,7 @@ pub fn init(syst: &SystemTable<Boot>) {
     let virt_efi =
         paging::LAddr::from(EFI_ID_OFFSET)..paging::LAddr::from(INITIAL_ID_SPACE + EFI_ID_OFFSET);
     let pg_attr = paging::Attr::KERNEL_RW;
-    
+
     maps(syst, virt_efi, phys, pg_attr).expect("Failed to map virtual memory for H2O boot");
 }
 

--- a/h2o/boot/src/mem.rs
+++ b/h2o/boot/src/mem.rs
@@ -82,11 +82,6 @@ pub fn init(syst: &SystemTable<Boot>) {
 
     unsafe { ROOT_TABLE.as_mut_ptr().write(rt) };
 
-    let phys = paging::PAddr::new(0);
-    let virt_efi =
-        paging::LAddr::from(EFI_ID_OFFSET)..paging::LAddr::from(INITIAL_ID_SPACE + EFI_ID_OFFSET);
-    let pg_attr = paging::Attr::KERNEL_RW;
-
     for i in (paging::NR_ENTRIES / 2)..paging::NR_ENTRIES {
         let phys = unsafe { alloc(syst).allocate_zeroed(EFI_ID_OFFSET) }
             .expect("Failed to allocate a page");
@@ -98,6 +93,11 @@ pub fn init(syst: &SystemTable<Boot>) {
         "mapping kernel's pages 0 ~ 4G: root_phys = {:?}",
         rt.as_ptr()
     );
+    let phys = paging::PAddr::new(0);
+    let virt_efi =
+        paging::LAddr::from(EFI_ID_OFFSET)..paging::LAddr::from(INITIAL_ID_SPACE + EFI_ID_OFFSET);
+    let pg_attr = paging::Attr::KERNEL_RW;
+    
     maps(syst, virt_efi, phys, pg_attr).expect("Failed to map virtual memory for H2O boot");
 }
 

--- a/h2o/kernel/src/cpu/time.rs
+++ b/h2o/kernel/src/cpu/time.rs
@@ -6,6 +6,7 @@ use core::{
     time::Duration,
 };
 
+use self::chip::ClockChip;
 pub use self::timer::{tick as timer_tick, Timer};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/h2o/kernel/src/sched/task/boot.rs
+++ b/h2o/kernel/src/sched/task/boot.rs
@@ -8,7 +8,7 @@ use targs::Targs;
 
 use super::{hdl::DefaultFeature, *};
 use crate::{
-    cpu::arch::tsc::TSC_CLOCK,
+    cpu::time::chip::CLOCK,
     mem::space::{self, Flags, Phys, PhysTrait, Virt},
     sched::SCHED,
 };
@@ -56,9 +56,9 @@ fn flags_to_feat(flags: Flags) -> Feature {
 pub fn setup() {
     unsafe {
         let constants = sv_call::Constants {
-            ticks_offset: TSC_CLOCK.initial,
-            ticks_multiplier: TSC_CLOCK.mul,
-            ticks_shift: TSC_CLOCK.sft,
+            ticks_offset: CLOCK.initial,
+            ticks_multiplier: CLOCK.mul,
+            ticks_shift: CLOCK.sft,
             has_builtin_rand: archop::rand::has_builtin(),
             num_cpus: crate::cpu::count(),
         };

--- a/h2o/libs/minfo/src/lib.rs
+++ b/h2o/libs/minfo/src/lib.rs
@@ -12,7 +12,7 @@ pub const TRAMPOLINE_RANGE: core::ops::Range<usize> = 0..0x100000;
 
 pub const LAPIC_BASE: usize = 0xFEE0_0000;
 
-pub const INITIAL_ID_SPACE: usize = 0x1_0000_0000;
+pub const INITIAL_ID_SPACE: usize = 0x2_0000_0000;
 
 pub use pmm::{KMEM_PHYS_BASE, PF_SIZE};
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,12 +4,12 @@ if [ $1 = "qemu" ]; then
       qemu-system-x86_64 -L /usr/share/ovmf -bios OVMF.fd \
             -m 4096 -cpu max -smp $2 -serial file:debug/qemu.log \
             -drive format=raw,file=target/img/efi.img -boot c \
-            -monitor stdio $3 $4 $5 $6 $7 $8 $9
+            -monitor stdio -M q35 $3 $4 $5 $6 $7 $8 $9
 elif [ $1 = "qdbg" ]; then
       qemu-system-x86_64 -L /usr/share/ovmf -bios OVMF.fd \
             -m 4096 -cpu max -smp $2 -serial file:debug/qemu.log \
             -drive format=raw,file=target/img/efi.img -boot c \
-            -monitor stdio -s -S $3 $4 $5 $6 $7 $8 $9
+            -monitor stdio -M q35 -s -S $3 $4 $5 $6 $7 $8 $9
 elif [ $1 = "vbox" ]; then
     /usr/lib/virtualbox/VirtualBoxVM --startvm "OV3" --dbg $2 $3 $4 $5 $6 $7 $8 $9
 elif [ $1 = "vmware" ]; then


### PR DESCRIPTION
Qemu Q35 chipset places the boot EFI image above 4G physical memory space, so we must adapt to that, making a larger identical mappings in h2o_boot. Also, the kernel time module should be simplified.